### PR TITLE
Fix sorting of Damage column in weapon overview tables

### DIFF
--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintArchergunsOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintArchergunsOverview.java
@@ -66,8 +66,8 @@ public class CommandPrintArchergunsOverview extends CommandBase {
 			archerguns = archerguns.stream().sorted(Comparator.comparing(archergun -> archergun.getItemStackDisplayName(new ItemStack(archergun)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Unholster time !! Fire rate !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Unholster time !! Fire rate !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseArchergun archergun : archerguns) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintAxesOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintAxesOverview.java
@@ -64,8 +64,8 @@ public class CommandPrintAxesOverview extends CommandBase {
 			axes = axes.stream().sorted(Comparator.comparing(axe -> axe.getItemStackDisplayName(new ItemStack(axe)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Efficiency !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Efficiency !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseAxe axe : axes) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintBlastersOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintBlastersOverview.java
@@ -66,8 +66,8 @@ public class CommandPrintBlastersOverview extends CommandBase {
 			blasters = blasters.stream().sorted(Comparator.comparing(blaster -> blaster.getItemStackDisplayName(new ItemStack(blaster)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Unholster time !! Fire rate !! Energy cost !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Unholster time !! Fire rate !! Energy cost !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseBlaster blaster : blasters) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintBowsOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintBowsOverview.java
@@ -62,8 +62,8 @@ public class CommandPrintBowsOverview extends CommandBase {
 			bows = bows.stream().sorted(Comparator.comparing(bow -> bow.getItemStackDisplayName(new ItemStack(bow)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Draw time !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Draw time !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseBow bow : bows) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintCannonsOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintCannonsOverview.java
@@ -66,8 +66,8 @@ public class CommandPrintCannonsOverview extends CommandBase {
 			cannons = cannons.stream().sorted(Comparator.comparing(cannon -> cannon.getItemStackDisplayName(new ItemStack(cannon)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Unholster time !! Fire rate !! Recoil !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Unholster time !! Fire rate !! Recoil !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseCannon cannon : cannons) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintGreatbladesOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintGreatbladesOverview.java
@@ -66,8 +66,8 @@ public class CommandPrintGreatbladesOverview extends CommandBase {
 			greatblades = greatblades.stream().sorted(Comparator.comparing(greatblade -> greatblade.getItemStackDisplayName(new ItemStack(greatblade)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Attack speed !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Attack speed !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseGreatblade greatblade : greatblades) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintGunsOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintGunsOverview.java
@@ -71,8 +71,8 @@ public class CommandPrintGunsOverview extends CommandBase {
 			guns = guns.stream().sorted(Comparator.comparing(gun -> gun.getItemStackDisplayName(new ItemStack(gun)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Unholster time !! Fire rate !! Recoil !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Unholster time !! Fire rate !! Recoil !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseGun gun : guns) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintMaulsOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintMaulsOverview.java
@@ -66,8 +66,8 @@ public class CommandPrintMaulsOverview extends CommandBase {
 			mauls = mauls.stream().sorted(Comparator.comparing(maul -> maul.getItemStackDisplayName(new ItemStack(maul)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Attack speed !! Knockback !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Attack speed !! Knockback !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseMaul maul : mauls) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintPickaxesOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintPickaxesOverview.java
@@ -64,8 +64,8 @@ public class CommandPrintPickaxesOverview extends CommandBase {
 			pickaxes = pickaxes.stream().sorted(Comparator.comparing(pickaxe -> pickaxe.getItemStackDisplayName(new ItemStack(pickaxe)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Efficiency !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Efficiency !! Durability !! Effects");
 			data.add("|-");
 
 			for (BasePickaxe pickaxe : pickaxes) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintShotgunsOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintShotgunsOverview.java
@@ -66,8 +66,8 @@ public class CommandPrintShotgunsOverview extends CommandBase {
 			shotguns = shotguns.stream().sorted(Comparator.comparing(shotgun -> shotgun.getItemStackDisplayName(new ItemStack(shotgun)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Unholster time !! Fire rate !! Pellets !! Recoil !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Unholster time !! Fire rate !! Pellets !! Recoil !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseShotgun shotgun : shotguns) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintShovelsOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintShovelsOverview.java
@@ -64,8 +64,8 @@ public class CommandPrintShovelsOverview extends CommandBase {
 			shovels = shovels.stream().sorted(Comparator.comparing(shovel -> shovel.getItemStackDisplayName(new ItemStack(shovel)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Efficiency !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Efficiency !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseShovel shovel : shovels) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintSnipersOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintSnipersOverview.java
@@ -66,8 +66,8 @@ public class CommandPrintSnipersOverview extends CommandBase {
 			snipers = snipers.stream().sorted(Comparator.comparing(sniper -> sniper.getItemStackDisplayName(new ItemStack(sniper)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Unholster time !! Fire rate !! Recoil !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Unholster time !! Fire rate !! Recoil !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseSniper sniper : snipers) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintSwordsOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintSwordsOverview.java
@@ -66,8 +66,8 @@ public class CommandPrintSwordsOverview extends CommandBase {
 			swords = swords.stream().sorted(Comparator.comparing(sword -> sword.getItemStackDisplayName(new ItemStack(sword)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Attack speed !! Durability !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Attack speed !! Durability !! Effects");
 			data.add("|-");
 
 			for (BaseSword sword : swords) {

--- a/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintThrownWeaponsOverview.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/weaponcategories/CommandPrintThrownWeaponsOverview.java
@@ -63,8 +63,8 @@ public class CommandPrintThrownWeaponsOverview extends CommandBase {
 			thrownWeapons = thrownWeapons.stream().sorted(Comparator.comparing(thrownWeapon -> thrownWeapon.getItemStackDisplayName(new ItemStack(thrownWeapon)))).collect(Collectors.toList());
 
 			data.add("{| cellpadding=\"5\" class=\"sortable\" width=\"100%\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
-			data.add("|- style=\"background-color:#eee\" | data-sort-type=number |");
-			data.add("! Name !! Damage !! Throw rate !! Effects");
+			data.add("|- style=\"background-color:#eee\"");
+			data.add("! Name !! data-sort-type=number | Damage !! Throw rate !! Effects");
 			data.add("|-");
 
 			for (BaseThrownWeapon thrownWeapon : thrownWeapons) {


### PR DESCRIPTION
This fixes the sorting of the "Damage" column in the weapon overview tables, which was broken previously due to the `{{hp}}` template (causing it to sort alphabetically instead of numerically by default). Compare the sorting on [Bows](https://adventofascension.gamepedia.com/Bows#List_of_Bows) (new) vs [Swords](https://adventofascension.gamepedia.com/Swords#List_of_Swords) (old/broken).