### PR TITLE
Finish most 1.15.2 functionality

### DIFF
--- a/src/main/java/net/tslat/aoawikihelpermod/AoAWikiHelperMod.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/AoAWikiHelperMod.java
@@ -52,11 +52,11 @@ public class AoAWikiHelperMod
     public void serverStarting(FMLServerStartingEvent evt)
     {
         RecipeWriter.scrapeForRecipes(aoaModContainer);
-
         RecipeWriter.registerRecipeInterface("InfusionRecipe", RecipeInterfaceInfusion.class);
         RecipeWriter.registerRecipeInterface("ShapedRecipe", RecipeInterfaceShaped.class);
         RecipeWriter.registerRecipeInterface("ShapelessRecipe", RecipeInterfaceShapeless.class);
 
+        PrintInfusionEnchantsCommand.register(evt.getCommandDispatcher());
         PrintItemRecipesCommand.register(evt.getCommandDispatcher());
         PrintItemUsageRecipesCommand.register(evt.getCommandDispatcher());
 

--- a/src/main/java/net/tslat/aoawikihelpermod/AoAWikiHelperMod.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/AoAWikiHelperMod.java
@@ -16,6 +16,7 @@ import net.minecraftforge.fml.loading.FMLPaths;
 import net.tslat.aoawikihelpermod.dataprintouts.PrintEntityDataCommand;
 import net.tslat.aoawikihelpermod.dataprintouts.PrintHunterCreatureDataCommand;
 import net.tslat.aoawikihelpermod.dataprintouts.PrintWeaponsDataCommand;
+import net.tslat.aoawikihelpermod.loottables.PrintLootTableCommand;
 import net.tslat.aoawikihelpermod.recipes.*;
 import net.tslat.aoawikihelpermod.trades.PrintTradeOutputsCommand;
 import net.tslat.aoawikihelpermod.trades.PrintTradeUsagesCommand;
@@ -63,6 +64,8 @@ public class AoAWikiHelperMod
         PrintEntityDataCommand.register(evt.getCommandDispatcher());
         PrintHunterCreatureDataCommand.register(evt.getCommandDispatcher());
         PrintWeaponsDataCommand.register(evt.getCommandDispatcher());
+
+        PrintLootTableCommand.register(evt.getCommandDispatcher());
 
         PrintInfusionEnchantsCommand.register(evt.getCommandDispatcher());
         PrintItemRecipesCommand.register(evt.getCommandDispatcher());

--- a/src/main/java/net/tslat/aoawikihelpermod/AoAWikiHelperMod.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/AoAWikiHelperMod.java
@@ -18,6 +18,7 @@ import net.tslat.aoawikihelpermod.dataprintouts.PrintEntityDataCommand;
 import net.tslat.aoawikihelpermod.dataprintouts.PrintHunterCreatureDataCommand;
 import net.tslat.aoawikihelpermod.dataprintouts.PrintWeaponsDataCommand;
 import net.tslat.aoawikihelpermod.loottables.PrintLootTableCommand;
+import net.tslat.aoawikihelpermod.loottables.TestLootTableCommand;
 import net.tslat.aoawikihelpermod.recipes.*;
 import net.tslat.aoawikihelpermod.trades.PrintTradeOutputsCommand;
 import net.tslat.aoawikihelpermod.trades.PrintTradeUsagesCommand;
@@ -68,6 +69,7 @@ public class AoAWikiHelperMod
         PrintWeaponsDataCommand.register(evt.getCommandDispatcher());
 
         PrintLootTableCommand.register(evt.getCommandDispatcher());
+        TestLootTableCommand.register(evt.getCommandDispatcher());
 
         PrintInfusionEnchantsCommand.register(evt.getCommandDispatcher());
         PrintItemRecipesCommand.register(evt.getCommandDispatcher());

--- a/src/main/java/net/tslat/aoawikihelpermod/AoAWikiHelperMod.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/AoAWikiHelperMod.java
@@ -13,6 +13,9 @@ import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.fml.loading.FMLPaths;
+import net.tslat.aoawikihelpermod.dataprintouts.PrintEntityDataCommand;
+import net.tslat.aoawikihelpermod.dataprintouts.PrintHunterCreatureDataCommand;
+import net.tslat.aoawikihelpermod.dataprintouts.PrintWeaponsDataCommand;
 import net.tslat.aoawikihelpermod.recipes.*;
 import net.tslat.aoawikihelpermod.trades.PrintTradeOutputsCommand;
 import net.tslat.aoawikihelpermod.trades.PrintTradeUsagesCommand;
@@ -22,6 +25,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.annotation.Nonnull;
 import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.io.BufferedReader;
@@ -55,6 +59,10 @@ public class AoAWikiHelperMod
         RecipeWriter.registerRecipeInterface("InfusionRecipe", RecipeInterfaceInfusion.class);
         RecipeWriter.registerRecipeInterface("ShapedRecipe", RecipeInterfaceShaped.class);
         RecipeWriter.registerRecipeInterface("ShapelessRecipe", RecipeInterfaceShapeless.class);
+
+        PrintEntityDataCommand.register(evt.getCommandDispatcher());
+        PrintHunterCreatureDataCommand.register(evt.getCommandDispatcher());
+        PrintWeaponsDataCommand.register(evt.getCommandDispatcher());
 
         PrintInfusionEnchantsCommand.register(evt.getCommandDispatcher());
         PrintItemRecipesCommand.register(evt.getCommandDispatcher());
@@ -122,6 +130,28 @@ public class AoAWikiHelperMod
         }
 
         return false;
+    }
+
+    public static String capitaliseAllWords(@Nonnull String input) {
+        if (input.isEmpty())
+            return input;
+
+        StringBuilder buffer = new StringBuilder(input.length()).append(Character.toTitleCase(input.charAt(0)));
+
+        for (int i = 1; i < input.length(); i++) {
+            char ch = input.charAt(i);
+
+            if (Character.isWhitespace(ch)) {
+                buffer.append(ch);
+                buffer.append(Character.toTitleCase(input.charAt(i + 1)));
+                i++;
+            }
+            else {
+                buffer.append(ch);
+            }
+        }
+
+        return buffer.toString();
     }
 
 }

--- a/src/main/java/net/tslat/aoawikihelpermod/AoAWikiHelperMod.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/AoAWikiHelperMod.java
@@ -13,6 +13,7 @@ import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.fml.loading.FMLPaths;
+import net.tslat.aoawikihelpermod.dataprintouts.PrintEntitiesDropListCommand;
 import net.tslat.aoawikihelpermod.dataprintouts.PrintEntityDataCommand;
 import net.tslat.aoawikihelpermod.dataprintouts.PrintHunterCreatureDataCommand;
 import net.tslat.aoawikihelpermod.dataprintouts.PrintWeaponsDataCommand;
@@ -61,6 +62,7 @@ public class AoAWikiHelperMod
         RecipeWriter.registerRecipeInterface("ShapedRecipe", RecipeInterfaceShaped.class);
         RecipeWriter.registerRecipeInterface("ShapelessRecipe", RecipeInterfaceShapeless.class);
 
+        PrintEntitiesDropListCommand.register(evt.getCommandDispatcher());
         PrintEntityDataCommand.register(evt.getCommandDispatcher());
         PrintHunterCreatureDataCommand.register(evt.getCommandDispatcher());
         PrintWeaponsDataCommand.register(evt.getCommandDispatcher());

--- a/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/DataPrintoutWriter.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/DataPrintoutWriter.java
@@ -37,7 +37,7 @@ public class DataPrintoutWriter {
             return;
         }
 
-        String fileName = targetStack.getItem().getDisplayName(targetStack).getString() + " Output Trades.txt";
+        String fileName = targetStack.getItem().getDisplayName(targetStack).getString() + " Entity Sources.txt";
         ArrayList<String> entities = new ArrayList<String>();
         World world = ServerLifecycleHooks.getCurrentServer().getWorld(DimensionType.OVERWORLD);
         enableWriter(fileName);

--- a/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/DataPrintoutWriter.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/DataPrintoutWriter.java
@@ -84,7 +84,8 @@ public class DataPrintoutWriter {
 
         disableWriter();
         sender.sendMessage(AoAWikiHelperMod.generateInteractiveMessagePrintout("Printed out " + entities.size() + " entities that drop ", new File(configDir, fileName), targetStack.getDisplayName(), copyToClipboard && AoAWikiHelperMod.copyFileToClipboard(new File(configDir, fileName)) ? ". Copied to clipboard" : ""));
-    }*/
+    }
+    */
 
     public static void writeData(String name, List<String> data, ICommandSource sender, boolean copyToClipboard) {
         String fileName = name + " Printout " + AdventOfAscension.VERSION + ".txt";

--- a/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/DataPrintoutWriter.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/DataPrintoutWriter.java
@@ -1,0 +1,127 @@
+package net.tslat.aoawikihelpermod.dataprintouts;
+
+import net.minecraft.command.ICommandSource;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.World;
+import net.minecraft.world.dimension.DimensionType;
+import net.minecraft.world.storage.loot.LootPool;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
+import net.tslat.aoa3.advent.AdventOfAscension;
+import net.tslat.aoawikihelpermod.AoAWikiHelperMod;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class DataPrintoutWriter {
+    public static File configDir = null;
+    private static PrintWriter writer = null;
+
+    /*
+    public static void writeItemEntityDropsList(ICommandSource sender, ItemStack targetStack, boolean copyToClipboard) {
+        if (writer != null) {
+            sender.sendMessage(new StringTextComponent("You're already outputting data! Wait a moment and try again"));
+
+            return;
+        }
+
+        String fileName = targetStack.getItem().getDisplayName(targetStack).getString() + " Output Trades.txt";
+        ArrayList<String> entities = new ArrayList<String>();
+        World world = ServerLifecycleHooks.getCurrentServer().getWorld(DimensionType.OVERWORLD);
+        Method lootTableMethod = ObfuscationReflectionHelper.findMethod(LivingEntity.class, "func_184647_J", ResourceLocation.class);
+
+        enableWriter(fileName);
+
+        for (EntityEntry entry : ForgeRegistries.ENTITIES.getValuesCollection()) {
+            if (!LivingEntity.class.isAssignableFrom(entry.getEntityClass()))
+                continue;
+
+            LivingEntity entity = (LivingEntity)entry.newInstance(world);
+            LootTable table;
+
+            try {
+                ResourceLocation tableLocation = (ResourceLocation)lootTableMethod.invoke(entity);
+
+                if (tableLocation == null)
+                    continue;
+
+                table = world.getLootTableManager().getLootTableFromLocation(tableLocation);
+            }
+            catch (Exception e) {
+                continue;
+            }
+
+            if (table == LootTable.EMPTY_LOOT_TABLE)
+                continue;
+
+            List<LootPool> pools = ObfuscationReflectionHelper.getPrivateValue(LootTable.class, table, "field_186466_c");
+            AccessibleLootTable accessibleTable = new AccessibleLootTable(pools, "");
+
+            for (AccessibleLootTable.AccessibleLootPool pool : accessibleTable.pools) {
+                for (AccessibleLootTable.AccessibleLootEntry poolEntry : pool.lootEntries) {
+                    if (poolEntry.item == targetStack.getItem())
+                        entities.add(entity.getDisplayName().getUnformattedText());
+                }
+            }
+        }
+
+        if (entities.size() >= 15) {
+            write("Click 'Expand' to see a list of mobs that drop " + targetStack.getItem().getDisplayName(targetStack).getString());
+            write("<div class=\"mw-collapsible mw-collapsed\">");
+        }
+
+        entities.sort(Comparator.naturalOrder());
+        entities.forEach(e -> write("* [[" + e + "]]"));
+
+        disableWriter();
+        sender.sendMessage(AoAWikiHelperMod.generateInteractiveMessagePrintout("Printed out " + entities.size() + " entities that drop ", new File(configDir, fileName), targetStack.getDisplayName(), copyToClipboard && AoAWikiHelperMod.copyFileToClipboard(new File(configDir, fileName)) ? ". Copied to clipboard" : ""));
+    }*/
+
+    public static void writeData(String name, List<String> data, ICommandSource sender, boolean copyToClipboard) {
+        String fileName = name + " Printout " + AdventOfAscension.VERSION + ".txt";
+
+        enableWriter(fileName);
+
+        data.forEach(DataPrintoutWriter::write);
+
+        disableWriter();
+        sender.sendMessage(AoAWikiHelperMod.generateInteractiveMessagePrintout("Generated data file: ", new File(configDir, fileName), name, copyToClipboard && AoAWikiHelperMod.copyFileToClipboard(new File(configDir, fileName)) ? ". Copied to clipboard" : ""));
+    }
+
+    private static void enableWriter(final String fileName) {
+        configDir = AoAWikiHelperMod.prepConfigDir("Data Printouts");
+
+        File streamFile = new File(configDir, fileName);
+
+        try {
+            if (streamFile.exists())
+                streamFile.delete();
+
+            streamFile.createNewFile();
+
+            writer = new PrintWriter(streamFile);
+        }
+        catch (Exception e) {}
+    }
+
+    private static void disableWriter() {
+        if (writer != null)
+            IOUtils.closeQuietly(writer);
+
+        writer = null;
+    }
+
+    private static void write(String line) {
+        if (writer != null)
+            writer.println(line);
+    }
+}

--- a/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/PrintEntitiesDropListCommand.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/PrintEntitiesDropListCommand.java
@@ -1,0 +1,77 @@
+package net.tslat.aoawikihelpermod.dataprintouts;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.World;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.tslat.aoa3.item.weapon.cannon.BaseCannon;
+import net.tslat.aoa3.util.NumberUtil;
+import net.tslat.aoawikihelpermod.AttributeHandler;
+import net.tslat.aoawikihelpermod.weaponcategories.CategoryTableWriter;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PrintEntitiesDropListCommand {
+    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+        dispatcher.register(
+                Commands.literal("printentitiesdroplist")
+                        .then(Commands.argument("copyToClipboard", BoolArgumentType.bool())
+                                .executes(commandContext -> {
+                                    print(commandContext, BoolArgumentType.getBool(commandContext, "copyToClipboard"));
+                                    return 0;
+                                }))
+                        .executes(commandContext -> {
+                            print(commandContext, false);
+                            return 0;
+                        }));
+    }
+
+    public static void print(CommandContext<CommandSource> context, boolean attemptToCopy) {
+        Entity sender = context.getSource().getEntity();
+
+        if(!(sender instanceof PlayerEntity)) {
+            sender.sendMessage(new StringTextComponent("This command can only be done ingame for accuracy."));
+            return;
+        }
+
+        PlayerEntity player = (PlayerEntity)sender;
+
+        World world = context.getSource().getWorld();
+
+        if(!world.isRemote) {
+            boolean copyToClipboard = attemptToCopy;
+            if (copyToClipboard && context.getSource().getServer().isDedicatedServer()) {
+                sender.sendMessage(new StringTextComponent("Can't copy contents of file to clipboard on dedicated servers, skipping."));
+                copyToClipboard = false;
+            }
+
+            ItemStack targetStack = player.getHeldItemMainhand();
+
+            if (targetStack.isEmpty()) {
+                sender.sendMessage(new StringTextComponent("You're not holding anything!"));
+
+                return;
+            }
+            else if (!targetStack.getItem().getRegistryName().getNamespace().equals("aoa3")) {
+                sender.sendMessage(new StringTextComponent("The item you are holding is not from AoA! You are holding: " + targetStack.getDisplayName() + " (" + targetStack.getItem().getRegistryName().toString() + ")"));
+
+                return;
+            }
+
+            DataPrintoutWriter.writeItemEntityDropsList(sender, targetStack, copyToClipboard);
+        }
+    }
+}

--- a/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/PrintEntityDataCommand.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/PrintEntityDataCommand.java
@@ -1,0 +1,189 @@
+package net.tslat.aoawikihelpermod.dataprintouts;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.entity.*;
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.World;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.tslat.aoa3.advent.AdventOfAscension;
+import net.tslat.aoa3.entity.base.*;
+import net.tslat.aoa3.entity.minion.AoAMinion;
+import net.tslat.aoa3.entity.mob.creeponia.AoACreeponiaCreeper;
+import net.tslat.aoa3.util.NumberUtil;
+import net.tslat.aoa3.util.skill.HunterUtil;
+
+import java.util.*;
+
+import static net.minecraft.entity.CreatureAttribute.*;
+
+public class PrintEntityDataCommand {
+    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+        dispatcher.register(
+                Commands.literal("printentitydata")
+                        .then(Commands.argument("copyToClipboard", BoolArgumentType.bool())
+                                .executes(commandContext -> {
+                                    print(commandContext, BoolArgumentType.getBool(commandContext, "copyToClipboard"));
+                                    return 0;
+                                }))
+                        .executes(commandContext -> {
+                            print(commandContext, false);
+                            return 0;
+                        }));
+    }
+
+    public static void print(CommandContext<CommandSource> context, boolean attemptToCopy) {
+        Entity sender = context.getSource().getEntity();
+
+        if(!(sender instanceof PlayerEntity)) {
+            sender.sendMessage(new StringTextComponent("This command can only be done ingame for accuracy."));
+            return;
+        }
+
+        PlayerEntity player = (PlayerEntity)sender;
+
+        World world = context.getSource().getWorld();
+
+        if(!world.isRemote) {
+            boolean copyToClipboard = attemptToCopy;
+            if (copyToClipboard && context.getSource().getServer().isDedicatedServer()) {
+                sender.sendMessage(new StringTextComponent("Can't copy contents of file to clipboard on dedicated servers, skipping."));
+                copyToClipboard = false;
+            }
+
+            List<String> data = new ArrayList<String>();
+
+            data.add("AoA v" + AdventOfAscension.VERSION + " entity data printout below: ");
+            data.add("");
+            data.add("---~~~---~~~---~~~");
+            HashMap<String, Integer> mobCounts = new HashMap<String, Integer>();
+
+            for (EntityType entry : ForgeRegistries.ENTITIES) {
+                if (!entry.getRegistryName().getNamespace().equals("aoa3"))
+                    continue;
+
+                Entity entity = entry.create(world);
+
+                data.add("Entity: " + entity.getName().getString());
+                data.add("Id: " + entry.getRegistryName());
+
+                String type = "Other";
+
+                if (!entity.isNonBoss()) {
+                    type = "Boss";
+                    mobCounts.merge("Boss", 1, Integer::sum);
+                }
+                else if (entity instanceof AoAMeleeMob) {
+                    if (entity instanceof AoARangedAttacker) {
+                        type = "Hybrid Melee/Ranged Mob";
+                        mobCounts.merge("Hybrid Melee/Ranged Mob", 1, Integer::sum);
+                    }
+                    else {
+                        type = "Melee Mob";
+                        mobCounts.merge("Melee Mob", 1, Integer::sum);
+                    }
+                }
+                else if (entity instanceof AoARangedMob) {
+                    type = "Ranged Mob";
+                    mobCounts.merge("Ranged Mob", 1, Integer::sum);
+                }
+                else if (entity instanceof AoAFlyingMeleeMob) {
+                    type = "Flying Melee Mob";
+                    mobCounts.merge("Flying Melee Mob", 1, Integer::sum);
+                }
+                else if (entity instanceof AoAFlyingRangedMob) {
+                    type = "Flying Ranged Mob";
+                    mobCounts.merge("Flying Ranged Mob", 1, Integer::sum);
+                }
+                else if (entity instanceof AoAAmbientNPC) {
+                    type = "NPC";
+                    mobCounts.merge("NPC", 1, Integer::sum);
+                }
+                else if (entity instanceof AoAMinion) {
+                    type = "Minion";
+                    mobCounts.merge("Minion", 1, Integer::sum);
+                }
+                else if (entity instanceof AnimalEntity) {
+                    type = "Animal";
+                    mobCounts.merge("Animal", 1, Integer::sum);
+                }
+                else if (entity instanceof AoATrader) {
+                    type = "Trader";
+                    mobCounts.merge("Trader", 1, Integer::sum);
+                }
+                else if (entity instanceof IProjectile) {
+                    type = "Projectile";
+                    mobCounts.merge("Projectile", 1, Integer::sum);
+                }
+                else {
+                    if (entity instanceof AoACreeponiaCreeper)
+                        type = "Creepoid";
+
+                    mobCounts.merge("Other", 1, Integer::sum);
+                }
+
+                data.add("Type: " + type);
+
+                if (entity instanceof LivingEntity) {
+                    LivingEntity livingEntity = (LivingEntity)entity;
+
+                    String creatureType = "None";
+
+                    CreatureAttribute creatureAttribute = livingEntity.getCreatureAttribute();
+
+                    if (creatureAttribute.equals(ARTHROPOD)) {
+                        creatureType = "Arthropod";
+                    } else if (creatureAttribute.equals(ILLAGER)) {
+                        creatureType = "Illager";
+                    } else if (creatureAttribute.equals(UNDEAD)) {
+                        creatureType = "Arthropod";
+                    }
+
+                    data.add("Creature Type: " + creatureType + (!entity.isNonBoss() ? " (Boss)" : ""));
+                    data.add("Size: " + entity.getWidth() + "W x " + entity.getHeight() + "H");
+                    data.add("Stats:");
+                    data.add("    Health: " + livingEntity.getAttribute(SharedMonsterAttributes.MAX_HEALTH).getBaseValue());
+                    data.add("    Armour: " + livingEntity.getAttribute(SharedMonsterAttributes.ARMOR).getBaseValue());
+                    data.add("    Knockback Resistance: " + NumberUtil.roundToNthDecimalPlace((float)livingEntity.getAttribute(SharedMonsterAttributes.KNOCKBACK_RESISTANCE).getBaseValue(), 2));
+                    data.add("    Movement Speed: " + NumberUtil.roundToNthDecimalPlace((float)livingEntity.getAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).getBaseValue(), 3));
+
+                    if (livingEntity.getAttribute(SharedMonsterAttributes.ATTACK_DAMAGE) != null)
+                        data.add("    Strength: " + livingEntity.getAttribute(SharedMonsterAttributes.ATTACK_DAMAGE).getBaseValue());
+
+                    if (livingEntity instanceof AoACreeponiaCreeper)
+                        data.add("    Explosion Strength: " + ((AoACreeponiaCreeper)livingEntity).getExplosionStrength());
+
+                    if (HunterUtil.isHunterCreature(livingEntity)) {
+                        data.add("    Hunter Level: " + HunterUtil.getHunterLevel(livingEntity));
+                        data.add("    Hunter Xp: " + HunterUtil.getHunterXp(livingEntity));
+                    }
+                }
+                else {
+                    data.add("Size: " + entity.getWidth() + "W x " + entity.getHeight() + "H");
+                }
+
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Entity printout complete, stats: ");
+
+            int total = 0;
+
+            for (Map.Entry<String, Integer> entry : mobCounts.entrySet()) {
+                data.add("    " + entry.getKey() + ": " + entry.getValue());
+                total += entry.getValue();
+            }
+
+            data.add("    Total: " + total);
+
+            DataPrintoutWriter.writeData("Entity", data, sender, copyToClipboard);
+        }
+    }
+}
+
+

--- a/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/PrintHunterCreatureDataCommand.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/PrintHunterCreatureDataCommand.java
@@ -1,0 +1,101 @@
+package net.tslat.aoawikihelpermod.dataprintouts;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.entity.*;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Tuple;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.tslat.aoa3.advent.AdventOfAscension;
+import net.tslat.aoa3.item.misc.RuneItem;
+import net.tslat.aoa3.item.weapon.blaster.BaseBlaster;
+import net.tslat.aoa3.item.weapon.bow.BaseBow;
+import net.tslat.aoa3.item.weapon.cannon.BaseCannon;
+import net.tslat.aoa3.item.weapon.crossbow.BaseCrossbow;
+import net.tslat.aoa3.item.weapon.greatblade.BaseGreatblade;
+import net.tslat.aoa3.item.weapon.gun.BaseGun;
+import net.tslat.aoa3.item.weapon.maul.BaseMaul;
+import net.tslat.aoa3.item.weapon.shotgun.BaseShotgun;
+import net.tslat.aoa3.item.weapon.sniper.BaseSniper;
+import net.tslat.aoa3.item.weapon.staff.BaseStaff;
+import net.tslat.aoa3.item.weapon.sword.BaseSword;
+import net.tslat.aoa3.item.weapon.thrown.BaseThrownWeapon;
+import net.tslat.aoa3.item.weapon.vulcane.BaseVulcane;
+import net.tslat.aoa3.util.NumberUtil;
+import net.tslat.aoa3.util.skill.HunterUtil;
+import net.tslat.aoawikihelpermod.AttributeHandler;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class PrintHunterCreatureDataCommand {
+    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+        dispatcher.register(
+                Commands.literal("printhuntercreaturedata")
+                        .then(Commands.argument("copyToClipboard", BoolArgumentType.bool())
+                                .executes(commandContext -> {
+                                    print(commandContext, BoolArgumentType.getBool(commandContext, "copyToClipboard"));
+                                    return 0;
+                                }))
+                        .executes(commandContext -> {
+                            print(commandContext, false);
+                            return 0;
+                        }));
+    }
+
+    public static void print(CommandContext<CommandSource> context, boolean attemptToCopy) {
+        Entity sender = context.getSource().getEntity();
+
+        if(!(sender instanceof PlayerEntity)) {
+            sender.sendMessage(new StringTextComponent("This command can only be done ingame for accuracy."));
+            return;
+        }
+
+        PlayerEntity player = (PlayerEntity)sender;
+
+        World world = context.getSource().getWorld();
+
+        if(!world.isRemote) {
+            boolean copyToClipboard = attemptToCopy;
+            if (copyToClipboard && context.getSource().getServer().isDedicatedServer()) {
+                sender.sendMessage(new StringTextComponent("Can't copy contents of file to clipboard on dedicated servers, skipping."));
+                copyToClipboard = false;
+            }
+
+            List<String> data = new ArrayList<String>();
+
+            data.add("{|class=\"wikitable\"");
+            data.add("|-");
+            data.add("! Mob !! Mob ID !! Default Level !! Default XP");
+            data.add("|-");
+
+            HashMap<EntityType<? extends MobEntity>, Tuple<Integer, Float>> hunterCreatureMap = ObfuscationReflectionHelper.getPrivateValue(HunterUtil.class, null, "hunterCreatureMap");
+
+            for (Map.Entry<EntityType<? extends MobEntity>, Tuple<Integer, Float>> entry : hunterCreatureMap.entrySet().stream().sorted(Comparator.comparing(e -> e.getKey().getRegistryName())).collect(Collectors.toList())) {
+                Entity entity = entry.getKey().create(world);
+
+                if (entity == null) {
+                    System.out.println("Unable to create entity with id: " + entry.getKey().getRegistryName());
+
+                    continue;
+                }
+
+                data.add("| [[" + entity.getDisplayName().getString() + "]] || " + entry.getKey().getRegistryName() + " || " + entry.getValue().getA() + " || " + entry.getValue().getB());
+                data.add("|-");
+            }
+
+            data.add("|}");
+
+            DataPrintoutWriter.writeData("Hunter Mobs", data, sender, copyToClipboard);
+        }
+    }
+}

--- a/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/PrintWeaponsDataCommand.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/dataprintouts/PrintWeaponsDataCommand.java
@@ -1,0 +1,336 @@
+package net.tslat.aoawikihelpermod.dataprintouts;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.entity.*;
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.World;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.tslat.aoa3.advent.AdventOfAscension;
+import net.tslat.aoa3.entity.base.*;
+import net.tslat.aoa3.entity.minion.AoAMinion;
+import net.tslat.aoa3.entity.mob.creeponia.AoACreeponiaCreeper;
+import net.tslat.aoa3.item.misc.RuneItem;
+import net.tslat.aoa3.item.weapon.blaster.BaseBlaster;
+import net.tslat.aoa3.item.weapon.bow.BaseBow;
+import net.tslat.aoa3.item.weapon.cannon.BaseCannon;
+import net.tslat.aoa3.item.weapon.crossbow.BaseCrossbow;
+import net.tslat.aoa3.item.weapon.greatblade.BaseGreatblade;
+import net.tslat.aoa3.item.weapon.gun.BaseGun;
+import net.tslat.aoa3.item.weapon.maul.BaseMaul;
+import net.tslat.aoa3.item.weapon.shotgun.BaseShotgun;
+import net.tslat.aoa3.item.weapon.sniper.BaseSniper;
+import net.tslat.aoa3.item.weapon.staff.BaseStaff;
+import net.tslat.aoa3.item.weapon.sword.BaseSword;
+import net.tslat.aoa3.item.weapon.thrown.BaseThrownWeapon;
+import net.tslat.aoa3.item.weapon.vulcane.BaseVulcane;
+import net.tslat.aoa3.util.NumberUtil;
+import net.tslat.aoa3.util.skill.HunterUtil;
+import net.tslat.aoawikihelpermod.AttributeHandler;
+
+import java.util.*;
+
+import static net.minecraft.entity.CreatureAttribute.*;
+
+public class PrintWeaponsDataCommand {
+    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+        dispatcher.register(
+                Commands.literal("printweaponsdata")
+                        .then(Commands.argument("copyToClipboard", BoolArgumentType.bool())
+                                .executes(commandContext -> {
+                                    print(commandContext, BoolArgumentType.getBool(commandContext, "copyToClipboard"));
+                                    return 0;
+                                }))
+                        .executes(commandContext -> {
+                            print(commandContext, false);
+                            return 0;
+                        }));
+    }
+
+    public static void print(CommandContext<CommandSource> context, boolean attemptToCopy) {
+        Entity sender = context.getSource().getEntity();
+
+        if(!(sender instanceof PlayerEntity)) {
+            sender.sendMessage(new StringTextComponent("This command can only be done ingame for accuracy."));
+            return;
+        }
+
+        PlayerEntity player = (PlayerEntity)sender;
+
+        World world = context.getSource().getWorld();
+
+        if(!world.isRemote) {
+            boolean copyToClipboard = attemptToCopy;
+            if (copyToClipboard && context.getSource().getServer().isDedicatedServer()) {
+                sender.sendMessage(new StringTextComponent("Can't copy contents of file to clipboard on dedicated servers, skipping."));
+                copyToClipboard = false;
+            }
+
+            List<String> data = new ArrayList<String>();
+
+            data.add("AoA v" + AdventOfAscension.VERSION + " weapons data printout below: ");
+            data.add("");
+            data.add("---~~~---~~~---~~~");
+
+            HashSet<BaseSword> swords = new HashSet<BaseSword>();
+            HashSet<BaseGreatblade> greatblades = new HashSet<BaseGreatblade>();
+            HashSet<BaseMaul> mauls = new HashSet<BaseMaul>();
+            HashSet<BaseShotgun> shotguns = new HashSet<BaseShotgun>();
+            HashSet<BaseSniper> snipers = new HashSet<BaseSniper>();
+            HashSet<BaseCannon> cannons = new HashSet<BaseCannon>();
+            HashSet<BaseBlaster> blasters = new HashSet<BaseBlaster>();
+            HashSet<BaseCrossbow> crossbows = new HashSet<BaseCrossbow>();
+            HashSet<BaseThrownWeapon> thrownWeapons = new HashSet<BaseThrownWeapon>();
+            HashSet<BaseGun> guns = new HashSet<BaseGun>();
+            HashSet<BaseVulcane> vulcanes = new HashSet<BaseVulcane>();
+            HashSet<BaseBow> bows = new HashSet<BaseBow>();
+            HashSet<BaseStaff> staves = new HashSet<BaseStaff>();
+
+            for (Item item : ForgeRegistries.ITEMS) {
+                if (item.getRegistryName().getNamespace().equals("aoa3")) {
+                    if (item instanceof BaseSword) {
+                        swords.add((BaseSword)item);
+                    }
+                    else if (item instanceof BaseGreatblade) {
+                        greatblades.add((BaseGreatblade)item);
+                    }
+                    else if (item instanceof BaseMaul) {
+                        mauls.add((BaseMaul)item);
+                    }
+                    else if (item instanceof BaseShotgun) {
+                        shotguns.add((BaseShotgun)item);
+                    }
+                    else if (item instanceof BaseSniper) {
+                        snipers.add((BaseSniper)item);
+                    }
+                    else if (item instanceof BaseCannon) {
+                        cannons.add((BaseCannon)item);
+                    }
+                    else if (item instanceof BaseBlaster) {
+                        blasters.add((BaseBlaster)item);
+                    }
+                    else if (item instanceof BaseCrossbow) {
+                        crossbows.add((BaseCrossbow)item);
+                    }
+                    else if (item instanceof BaseThrownWeapon) {
+                        thrownWeapons.add((BaseThrownWeapon)item);
+                    }
+                    else if (item instanceof BaseGun) {
+                        guns.add((BaseGun)item);
+                    }
+                    else if (item instanceof BaseVulcane) {
+                        vulcanes.add((BaseVulcane)item);
+                    }
+                    else if (item instanceof BaseBow) {
+                        bows.add((BaseBow)item);
+                    }
+                    else if (item instanceof BaseStaff) {
+                        staves.add((BaseStaff)item);
+                    }
+                }
+            }
+
+            data.add("Swords: ---~~~---~~~---~~~");
+
+            for (BaseSword sword : swords) {
+                data.add(new ItemStack(sword).getDisplayName().getString());
+                data.add("ID: " + sword.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage: " + sword.getAttackDamage());
+                data.add("    Durability: " + sword.getMaxDamage());
+                data.add("    Attack Speed: " + NumberUtil.roundToNthDecimalPlace((float)AttributeHandler.getStackAttributeValue(new ItemStack(sword), SharedMonsterAttributes.ATTACK_SPEED, (PlayerEntity)sender, EquipmentSlotType.MAINHAND, Item.ATTACK_SPEED_MODIFIER), 2));
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Greatblades: ---~~~---~~~---~~~");
+
+            for (BaseGreatblade greatblade : greatblades) {
+                data.add(new ItemStack(greatblade).getDisplayName().getString());
+                data.add("ID: " + greatblade.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage: " + greatblade.getAttackDamage());
+                data.add("    Durability: " + greatblade.getMaxDamage());
+                data.add("    Attack Speed: " + NumberUtil.roundToNthDecimalPlace((float)AttributeHandler.getStackAttributeValue(new ItemStack(greatblade), SharedMonsterAttributes.ATTACK_SPEED, (PlayerEntity)sender, EquipmentSlotType.MAINHAND, Item.ATTACK_SPEED_MODIFIER), 2));
+                data.add("    Reach: " + ((int)greatblade.getReach()) + " blocks");
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Mauls: ---~~~---~~~---~~~");
+
+            for (BaseMaul maul : mauls) {
+                data.add(new ItemStack(maul).getDisplayName().getString());
+                data.add("ID: " + maul.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage: " + maul.getAttackDamage());
+                data.add("    Durability: " + maul.getMaxDamage());
+                data.add("    Attack Speed: " + NumberUtil.roundToNthDecimalPlace((float)AttributeHandler.getStackAttributeValue(new ItemStack(maul), SharedMonsterAttributes.ATTACK_SPEED, (PlayerEntity)sender, EquipmentSlotType.MAINHAND, Item.ATTACK_SPEED_MODIFIER), 2));
+                data.add("    Knockback: " + (maul.getBaseKnockback()));
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Shotguns: ---~~~---~~~---~~~");
+
+            for (BaseShotgun shotgun : shotguns) {
+                data.add(new ItemStack(shotgun).getDisplayName().getString());
+                data.add("ID: " + shotgun.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage per pellet: " + shotgun.getDamage());
+                data.add("    Pellets: " + shotgun.getPelletCount());
+                data.add("    Durability: " + shotgun.getMaxDamage());
+                data.add("    Firing Speed: " + (2000 / shotgun.getFiringDelay()) / (double)100 + "/sec");
+                data.add("    Recoil: " + shotgun.getRecoil());
+
+                data.add("    Unholster Time: " + NumberUtil.roundToNthDecimalPlace(1 / (((int)(400 * (1 - (-AttributeHandler.getStackAttributeValue(new ItemStack(shotgun), SharedMonsterAttributes.ATTACK_SPEED, (PlayerEntity)sender, EquipmentSlotType.MAINHAND, AttributeHandler.ATTACK_SPEED_MAINHAND)) / 100f))) / 100f), 2) + "s");
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Snipers: ---~~~---~~~---~~~");
+
+            for (BaseSniper sniper : snipers) {
+                data.add(new ItemStack(sniper).getDisplayName().getString());
+                data.add("ID: " + sniper.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage per shot: " + sniper.getDamage());
+                data.add("    Durability: " + sniper.getMaxDamage());
+                data.add("    Firing Speed: " + (2000 / sniper.getFiringDelay()) / (double)100 + "/sec");
+                data.add("    Recoil: " + sniper.getRecoil());
+                data.add("    Unholster Time: " + NumberUtil.roundToNthDecimalPlace(1 / (((int)(400 * (1 - (-AttributeHandler.getStackAttributeValue(new ItemStack(sniper), SharedMonsterAttributes.ATTACK_SPEED, (PlayerEntity)sender, EquipmentSlotType.MAINHAND, AttributeHandler.ATTACK_SPEED_MAINHAND)) / 100f))) / 100f), 2) + "s");
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Guns: ---~~~---~~~---~~~");
+
+            for (BaseGun gun : guns) {
+                data.add(new ItemStack(gun).getDisplayName().getString());
+                data.add("ID: " + gun.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage per shot: " + gun.getDamage());
+                data.add("    Durability: " + gun.getMaxDamage());
+                data.add("    Firing Speed: " + (2000 / gun.getFiringDelay()) / (double)100 + "/sec");
+                data.add("    Recoil: " + gun.getRecoil());
+                data.add("    Unholster Time: " + NumberUtil.roundToNthDecimalPlace(1 / (((int)(400 * (1 - (-AttributeHandler.getStackAttributeValue(new ItemStack(gun), SharedMonsterAttributes.ATTACK_SPEED, (PlayerEntity)sender, EquipmentSlotType.MAINHAND, AttributeHandler.ATTACK_SPEED_MAINHAND)) / 100f))) / 100f), 2) + "s");
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Cannons: ---~~~---~~~---~~~");
+
+            for (BaseCannon cannon : cannons) {
+                data.add(new ItemStack(cannon).getDisplayName().getString());
+                data.add("ID: " + cannon.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage per shot: " + cannon.getDamage());
+                data.add("    Durability: " + cannon.getMaxDamage());
+                data.add("    Firing Speed: " + (2000 / cannon.getFiringDelay()) / (double)100 + "/sec");
+                data.add("    Recoil: " + cannon.getRecoil());
+                data.add("    Unholster Time: " + NumberUtil.roundToNthDecimalPlace(1 / (((int)(400 * (1 - (-AttributeHandler.getStackAttributeValue(new ItemStack(cannon), SharedMonsterAttributes.ATTACK_SPEED, (PlayerEntity)sender, EquipmentSlotType.MAINHAND, AttributeHandler.ATTACK_SPEED_MAINHAND)) / 100f))) / 100f), 2) + "s");
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Blasters: ---~~~---~~~---~~~");
+
+            for (BaseBlaster blaster : blasters) {
+                data.add(new ItemStack(blaster).getDisplayName().getString());
+                data.add("ID: " + blaster.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage: " + blaster.getDamage());
+                data.add("    Durability: " + blaster.getMaxDamage());
+                data.add("    Firing Speed: " + (2000 / blaster.getFiringDelay()) / (double)100 + "/sec");
+                data.add("    Energy Cost: " + blaster.getEnergyCost());
+                data.add("    Unholster Time: " + NumberUtil.roundToNthDecimalPlace(1 / (float)(AttributeHandler.getStackAttributeValue(new ItemStack(blaster), SharedMonsterAttributes.ATTACK_SPEED, (PlayerEntity)sender, EquipmentSlotType.MAINHAND, Item.ATTACK_SPEED_MODIFIER)), 2) + "s");
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Crossbows: ---~~~---~~~---~~~");
+
+            for (BaseCrossbow crossbow : crossbows) {
+                data.add(new ItemStack(crossbow).getDisplayName().getString());
+                data.add("ID: " + crossbow.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage per shot: " + crossbow.getDamage());
+                data.add("    Durability: " + crossbow.getMaxDamage());
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Bows: ---~~~---~~~---~~~");
+
+            for (BaseBow bow : bows) {
+                data.add(new ItemStack(bow).getDisplayName().getString());
+                data.add("ID: " + bow.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage per arrow: " + bow.getDamage());
+                data.add("    Durability: " + bow.getMaxDamage());
+                data.add("    Draw Time: " + (((int)(72000 / bow.getDrawSpeedMultiplier()) / 720) / (double)100) + "s");
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Thrown Weapons: ---~~~---~~~---~~~");
+
+            for (BaseThrownWeapon throwable : thrownWeapons) {
+                data.add(new ItemStack(throwable).getDisplayName().getString());
+                data.add("ID: " + throwable.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage: " + throwable.getDamage());
+                data.add("    Throw Speed: " + (2000 / throwable.getFiringDelay()) / (double)100 + "/sec");
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Vulcanes: ---~~~---~~~---~~~");
+
+            for (BaseVulcane vulcane : vulcanes) {
+                data.add(new ItemStack(vulcane).getDisplayName().getString());
+                data.add("ID: " + vulcane.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Damage: " + vulcane.getDamage());
+                data.add("    Durability: " + vulcane.getMaxDamage());
+                data.add("---~~~---~~~---~~~");
+            }
+
+            data.add("Staves: ---~~~---~~~---~~~");
+
+            for (BaseStaff staff : staves) {
+                data.add(new ItemStack(staff).getDisplayName().getString());
+                data.add("ID: " + staff.getRegistryName().toString());
+                data.add("Stats: ");
+                data.add("    Durability: " + staff.getMaxDamage());
+                data.add("    Runes: ");
+
+                Set<Map.Entry<RuneItem, Integer>> runes = staff.getRunes().entrySet();
+
+                for (Map.Entry<RuneItem, Integer> runeEntry : runes) {
+                    data.add("        " + runeEntry.getValue() + "x " + new ItemStack(runeEntry.getKey()).getDisplayName().getString());
+                }
+
+                data.add("---~~~---~~~---~~~");
+            }
+
+
+            data.add("Weapons printout complete, stats: ");
+            data.add("    Swords: " + swords.size());
+            data.add("    Greatblades: " + greatblades.size());
+            data.add("    Mauls: " + mauls.size());
+            data.add("    Shotguns: " + shotguns.size());
+            data.add("    Snipers: " + snipers.size());
+            data.add("    Cannons: " + cannons.size());
+            data.add("    Blasters: " + blasters.size());
+            data.add("    Crossbows: " + crossbows.size());
+            data.add("    Thrown Weapons: " + thrownWeapons.size());
+            data.add("    Guns: " + guns.size());
+            data.add("    Vulcanes: " + vulcanes.size());
+            data.add("    Bows: " + bows.size());
+            data.add("    Staves: " + staves.size());
+            data.add("");
+            data.add("Total: " + (swords.size() + greatblades.size() + mauls.size() + shotguns.size() + snipers.size() + cannons.size() + blasters.size() + crossbows.size() + thrownWeapons.size() + guns.size() + vulcanes.size() + bows.size() + staves.size()));
+            data.add("---~~~---~~~---~~~");
+
+            DataPrintoutWriter.writeData("Weapons", data, sender, copyToClipboard);
+        }
+    }
+}

--- a/src/main/java/net/tslat/aoawikihelpermod/loottables/AccessibleLootTable.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/loottables/AccessibleLootTable.java
@@ -1,0 +1,324 @@
+package net.tslat.aoawikihelpermod.loottables;
+
+import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.item.crafting.FurnaceRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.dimension.DimensionType;
+import net.minecraft.world.storage.loot.*;
+import net.minecraft.world.storage.loot.conditions.ILootCondition;
+import net.minecraft.world.storage.loot.conditions.KilledByPlayer;
+import net.minecraft.world.storage.loot.conditions.RandomChance;
+import net.minecraft.world.storage.loot.conditions.RandomChanceWithLooting;
+import net.minecraft.world.storage.loot.functions.ILootFunction;
+import net.minecraft.world.storage.loot.functions.LootingEnchantBonus;
+import net.minecraft.world.storage.loot.functions.SetCount;
+import net.minecraft.world.storage.loot.functions.Smelt;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.tslat.aoa3.entity.mob.overworld.ChargerEntity;
+import net.tslat.aoa3.library.loot.conditions.HoldingItem;
+import net.tslat.aoa3.library.loot.conditions.PlayerHasLevel;
+import net.tslat.aoa3.library.loot.functions.GrantSkillXp;
+import net.tslat.aoawikihelpermod.AoAWikiHelperMod;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.*;
+
+public class AccessibleLootTable {
+    public final List<AccessibleLootPool> pools;
+    public final String type;
+
+    public AccessibleLootTable(List<LootPool> pools, String type) {
+        this.pools = new ArrayList<AccessibleLootPool>(pools.size());
+        this.type = type;
+
+        for (LootPool pool : pools) {
+            this.pools.add(new AccessibleLootPool(pool, this));
+        }
+    }
+
+    public static class AccessibleLootPool {
+        public final List<AccessibleLootEntry> lootEntries;
+        public final IRandomRange rolls;
+        public final RandomValueRange bonusRolls;
+        public final List<ILootCondition> conditions;
+        public final StringBuilder notesBuilder = new StringBuilder();
+        public final AccessibleLootTable parentTable;
+
+        public AccessibleLootPool(LootPool pool, AccessibleLootTable parentTable) {
+            this.rolls = pool.getRolls();
+            this.bonusRolls = (RandomValueRange)pool.getBonusRolls();
+            this.parentTable = parentTable;
+
+            conditions = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, pool, "field_186454_b");
+            List<LootEntry> entries = ObfuscationReflectionHelper.getPrivateValue(LootPool.class, pool, "field_186453_a");
+            lootEntries = new ArrayList<AccessibleLootEntry>(entries.size());
+
+            for (LootEntry entry : entries) {
+                if (entry instanceof StandaloneLootEntry) {
+                    lootEntries.add(new AccessibleLootEntry((StandaloneLootEntry)entry, parentTable));
+                } else if (entry instanceof ParentedLootEntry) {
+                    AoAWikiHelperMod.LOGGER.error("Ran into ParentedLootEntry, have no idea how to deal with this");
+                } else {
+                    AoAWikiHelperMod.LOGGER.error("Ran into entry that wasn't either standalone or parented somehow");
+                }
+            }
+
+            lootEntries.sort(new LootEntryComparator());
+
+            if (conditions != null) {
+                boolean firstConditionPrinted = false;
+
+                for (ILootCondition condition : conditions) {
+                    if (condition instanceof RandomChance) {
+                        float chance = ObfuscationReflectionHelper.getPrivateValue(RandomChance.class, (RandomChance)condition, "field_186630_a");
+
+                        if (firstConditionPrinted)
+                            notesBuilder.append("<br/>");
+
+                        notesBuilder.append("This pool has a fixed ");
+                        notesBuilder.append(((int)(chance * 10000)) / 100d);
+                        notesBuilder.append("% chance to roll for drops. ");
+                    }
+                    else if (condition instanceof RandomChanceWithLooting) {
+                        float chance = ObfuscationReflectionHelper.getPrivateValue(RandomChanceWithLooting.class, (RandomChanceWithLooting)condition, "field_186627_a");
+                        float lootingMod = ObfuscationReflectionHelper.getPrivateValue(RandomChanceWithLooting.class, (RandomChanceWithLooting)condition, "field_186628_b");
+
+                        if (firstConditionPrinted)
+                            notesBuilder.append("<br/>");
+
+                        notesBuilder.append("This pool has a fixed ");
+                        notesBuilder.append(((int)(chance * 10000)) / 100d);
+                        notesBuilder.append("% chance to roll for drops, with an additional ");
+                        notesBuilder.append(((int)(lootingMod * 10000)) / 100d);
+                        notesBuilder.append("% chance per level of looting. ");
+                    }
+                    else if (condition instanceof KilledByPlayer) {
+                        if (firstConditionPrinted)
+                            notesBuilder.append("<br/>");
+
+                        notesBuilder.append("This pool will only roll if the entity is killed directly by a player. ");
+                    }
+                    else if (condition instanceof PlayerHasLevel) {
+                        String skill = I18n.format("skills." + ObfuscationReflectionHelper.getPrivateValue(PlayerHasLevel.class, (PlayerHasLevel)condition, "skill").toString().toLowerCase() + ".name");
+                        int level = ObfuscationReflectionHelper.getPrivateValue(PlayerHasLevel.class, (PlayerHasLevel)condition, "level");
+
+                        if (firstConditionPrinted)
+                            notesBuilder.append("<br/>");
+
+                        notesBuilder.append("This pool will only roll if the player has at least level ").append(level).append(" ").append(skill).append(". ");
+                    }
+                    else if (condition instanceof HoldingItem) {
+                        Item item = ObfuscationReflectionHelper.getPrivateValue(HoldingItem.class, (HoldingItem)condition, "tool");
+                        Hand hand = ObfuscationReflectionHelper.getPrivateValue(HoldingItem.class, (HoldingItem)condition, "hand");
+
+                        if (firstConditionPrinted)
+                            notesBuilder.append("<br/>");
+
+                        notesBuilder.append("This pool will only roll if the player is holding ").append(item.getDisplayName(new ItemStack(item)).toString());
+
+                        if (hand != null)
+                            notesBuilder.append(" in the ").append(hand.toString().toLowerCase().replace("_", ""));
+
+                        notesBuilder.append(". ");
+                    }
+                    else {
+                        continue;
+                    }
+
+                    firstConditionPrinted = true;
+                }
+            }
+        }
+
+        @Nonnull
+        public String getNotes() {
+            return notesBuilder.toString();
+        }
+
+        private static class LootEntryComparator implements Comparator<AccessibleLootEntry> {
+            @Override
+            public int compare(AccessibleLootEntry entry1, AccessibleLootEntry entry2) {
+                return Integer.compare(entry2.weight, entry1.weight);
+            }
+        }
+    }
+
+    public static class AccessibleLootEntry {
+        public final int weight;
+        public final int quality;
+        public final Item item;
+        public final ILootFunction[] functions;
+        public final ILootCondition[] conditions;
+
+        public ItemStack generatedStack = null;
+        public RandomValueRange amountRange = null;
+        public RandomValueRange bonusRange = null;
+        public StringBuilder notesBuilder = new StringBuilder();
+
+        public final boolean isTable;
+        public final ResourceLocation table;
+        public final AccessibleLootTable parentTable;
+
+        public AccessibleLootEntry(StandaloneLootEntry entry, AccessibleLootTable parentTable) {
+            this.isTable = entry instanceof TableLootEntry;
+            this.weight = ObfuscationReflectionHelper.getPrivateValue(StandaloneLootEntry.class, entry, "field_216158_e");
+            this.quality = ObfuscationReflectionHelper.getPrivateValue(StandaloneLootEntry.class, entry, "field_216159_f");
+            this.conditions = ObfuscationReflectionHelper.getPrivateValue(LootEntry.class, entry, "field_216144_d");
+            this.parentTable = parentTable;
+
+            if (entry instanceof ItemLootEntry) {
+                this.item = ObfuscationReflectionHelper.getPrivateValue(ItemLootEntry.class, (ItemLootEntry)entry, "field_186368_a");
+                this.functions = ObfuscationReflectionHelper.getPrivateValue(StandaloneLootEntry.class, entry, "field_216160_g");
+                this.table = null;
+            }
+            else if (isTable) {
+                this.table = ObfuscationReflectionHelper.getPrivateValue(TableLootEntry.class, (TableLootEntry)entry, "field_186371_a");
+                this.functions = null;
+                this.item = Items.AIR;
+            }
+            else {
+                this.item = Items.AIR;
+                this.functions = null;
+                this.table = null;
+            }
+            if (quality > 0) {
+                notesBuilder.append("Chance is increased with each level of luck");
+
+                if (parentTable.type.equals(""))
+                    notesBuilder.append(" and/or looting");
+
+                notesBuilder.append(".");
+            }
+            else if (quality < 0) {
+                notesBuilder.append("Chance is decreased with each level of luck");
+
+                if (parentTable.type.equals(""))
+                    notesBuilder.append(" and/or looting");
+
+                notesBuilder.append(".");
+            }
+        }
+
+        public String getEntryName(@Nullable PlayerEntity pl) {
+            if (item == Items.AIR) {
+                if (table == null)
+                    return "Nothing";
+
+                String tableName = table.getPath().substring(Math.max(0, table.getPath().indexOf(":")));
+                String[] splitName = tableName.split("/");
+                tableName = AoAWikiHelperMod.capitaliseAllWords(splitName[splitName.length - 1].replace("_", " ").replace(" table", ""));
+
+                if (!tableName.contains("table"))
+                    tableName = tableName + " Table";
+
+                return tableName;
+            }
+            else {
+                ItemStack stack = new ItemStack(item);
+                Random rand = new Random();
+                LootContext context;
+
+                try {
+                    //These are dummy parameters just to get into the loot table
+                    context = new LootContext.Builder(ServerLifecycleHooks.getCurrentServer().getWorld(DimensionType.OVERWORLD))
+                            .withParameter(LootParameters.POSITION, new BlockPos(0, 0, 0))
+                            .withParameter(LootParameters.THIS_ENTITY, ForgeRegistries.ENTITIES.getValue(new ResourceLocation("aoa3", "charger")).create(pl.getEntityWorld()))
+                            .withParameter(LootParameters.DAMAGE_SOURCE, DamageSource.causePlayerDamage(pl))
+                            .withParameter(LootParameters.LAST_DAMAGE_PLAYER, pl)
+                            .build(LootParameterSets.ENTITY);
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                    context = null;
+                }
+
+                if (functions != null) {
+                    for (int i = 0; i < functions.length; i++) {
+                        ILootFunction function = functions[i];
+
+                        try {
+                            function.apply(stack, context);
+
+                            if (function instanceof SetCount) {
+                                amountRange = ObfuscationReflectionHelper.getPrivateValue(SetCount.class, (SetCount)function, "field_186568_a");
+                            }
+                            else if (function instanceof LootingEnchantBonus) {
+                                bonusRange = ObfuscationReflectionHelper.getPrivateValue(LootingEnchantBonus.class, (LootingEnchantBonus)function, "field_186563_a");
+                            }
+                            else if (function instanceof Smelt) {
+                                Optional<FurnaceRecipe> smeltRecipe = (pl.getEntityWorld()).getRecipeManager().getRecipe(IRecipeType.SMELTING, new Inventory(new ItemStack[]{stack}), pl.getEntityWorld());
+                                if (smeltRecipe.isPresent()) {
+                                    ItemStack smeltedStack = ((FurnaceRecipe)smeltRecipe.get()).getRecipeOutput();
+
+                                    if (smeltedStack != ItemStack.EMPTY) {
+                                        notesBuilder.append("Converts to [[");
+
+                                        if (smeltedStack.getItem().getRegistryName().getNamespace().equals("minecraft")) {
+                                            notesBuilder.append("mcw:");
+                                            notesBuilder.append(smeltedStack.getDisplayName().getString());
+                                            notesBuilder.append("|");
+                                        }
+
+                                        notesBuilder.append(smeltedStack.getDisplayName().getString());
+                                        notesBuilder.append("]] if killed while the entity is on fire. ");
+                                    }
+                                } else {
+                                    AoAWikiHelperMod.LOGGER.error("Found smelting recipe for an unsmeltable item!");
+                                }
+                            }
+                            else if (function instanceof GrantSkillXp) {
+                                String skill = I18n.format("skills." + ObfuscationReflectionHelper.getPrivateValue(GrantSkillXp.class, (GrantSkillXp)function, "skill").toString().toLowerCase() + ".name");
+                                float xp = ObfuscationReflectionHelper.getPrivateValue(GrantSkillXp.class, (GrantSkillXp)function, "xp");
+
+                                notesBuilder.append("Gives ").append(xp).append("xp").append(" in ").append(skill);
+                            }/*
+                            else if (function instanceof SetRandomMetadata) {
+                                notesBuilder.append("Chooses a random variant from all possible variants of the item. ");
+                            }*/
+                        } catch (Exception e) {}
+                    }
+                }
+
+                if (conditions != null) {
+                    for (ILootCondition condition : conditions) {
+                        if (condition instanceof KilledByPlayer) {
+                            notesBuilder.append("Only drops if the entity is killed directly by a player. ");
+                        }
+                        else if (condition instanceof PlayerHasLevel) {
+                            String skill = I18n.format("skills." + ObfuscationReflectionHelper.getPrivateValue(PlayerHasLevel.class, (PlayerHasLevel)condition, "skill").toString().toLowerCase() + ".name");
+                            int level = ObfuscationReflectionHelper.getPrivateValue(PlayerHasLevel.class, (PlayerHasLevel)condition, "level");
+
+                            notesBuilder.append("Excluded from loot roll if the player does not have at least level ").append(level).append(" ").append(skill).append(". ");
+                        }
+                    }
+                }
+
+                if (amountRange == null)
+                    amountRange = new RandomValueRange(1);
+
+                stack.setCount(1);
+
+                generatedStack = stack;
+
+                return stack.getDisplayName().getString();
+            }
+
+        }
+
+        @Nonnull
+        public String getNotes() {
+            return notesBuilder.toString();
+        }
+    }
+}

--- a/src/main/java/net/tslat/aoawikihelpermod/loottables/AccessibleLootTable.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/loottables/AccessibleLootTable.java
@@ -1,5 +1,6 @@
 package net.tslat.aoawikihelpermod.loottables;
 
+import net.minecraft.advancements.criterion.ItemPredicate;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
@@ -8,6 +9,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.item.crafting.FurnaceRecipe;
 import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.tags.Tag;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.Hand;
 import net.minecraft.util.ResourceLocation;
@@ -120,14 +122,29 @@ public class AccessibleLootTable {
                         notesBuilder.append("This pool will only roll if the player has at least level ").append(level).append(" ").append(skill).append(". ");
                     }
                     else if (condition instanceof HoldingItem) {
-                        Item item = ObfuscationReflectionHelper.getPrivateValue(HoldingItem.class, (HoldingItem)condition, "tool");
+
+                        ItemPredicate predicate = ObfuscationReflectionHelper.getPrivateValue(HoldingItem.class, (HoldingItem)condition, "predicate");
                         Hand hand = ObfuscationReflectionHelper.getPrivateValue(HoldingItem.class, (HoldingItem)condition, "hand");
+
+                        Item item = ObfuscationReflectionHelper.getPrivateValue(ItemPredicate.class, predicate, "field_200313_b");
+                        Tag<Item> tag = ObfuscationReflectionHelper.getPrivateValue(ItemPredicate.class, predicate, "field_200314_c");
 
                         if (firstConditionPrinted)
                             notesBuilder.append("<br/>");
 
-                        notesBuilder.append("This pool will only roll if the player is holding ").append(item.getDisplayName(new ItemStack(item)).toString());
+                        String itemRequired;
 
+                        if(item != null && tag != null) {
+                            itemRequired = "...can an ItemPredicate even have both a tag and an item?";
+                        } else if (item != null) {
+                            itemRequired = item.getDisplayName(new ItemStack(item)).toString();
+                        } if (tag != null) {
+                            itemRequired = "an item with tag " + tag.getId();
+                        } else {
+                            itemRequired = "...nothing...this probably shouldn't happen";
+                        }
+
+                        notesBuilder.append("This pool will only roll if the player is holding ").append(itemRequired);
                         if (hand != null)
                             notesBuilder.append(" in the ").append(hand.toString().toLowerCase().replace("_", ""));
 

--- a/src/main/java/net/tslat/aoawikihelpermod/loottables/LootTableWriter.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/loottables/LootTableWriter.java
@@ -1,0 +1,130 @@
+package net.tslat.aoawikihelpermod.loottables;
+
+import net.minecraft.command.ICommandSource;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.world.storage.loot.ConstantRange;
+import net.minecraft.world.storage.loot.IRandomRange;
+import net.minecraft.world.storage.loot.LootPool;
+import net.minecraft.world.storage.loot.RandomValueRange;
+import net.tslat.aoawikihelpermod.AoAWikiHelperMod;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Random;
+
+public class LootTableWriter {
+    public static File configDir = null;
+    private static PrintWriter writer = null;
+
+    public static void writeTable(String name, List<LootPool> pools, ICommandSource sender, boolean copyToClipboard, String type) {
+        AccessibleLootTable table = new AccessibleLootTable(pools, type);
+        PlayerEntity pl = sender instanceof PlayerEntity ? (PlayerEntity)sender : null;
+        String fileName = name + " Loot Table.txt";
+
+        enableWriter(fileName);
+        write("{{LootTable");
+
+        if (!type.equals(""))
+            write("|type=" + type);
+
+        for (int i = 0; i < table.pools.size(); i++) {
+            AccessibleLootTable.AccessibleLootPool pool = table.pools.get(i);
+            int poolNum = i + 1;
+
+            write("|pool" + poolNum + "=");
+
+            for (AccessibleLootTable.AccessibleLootEntry entry : pool.lootEntries) {
+                String entryName = entry.getEntryName(pl);
+                String amount = entry.amountRange == null ? null : (entry.amountRange.getMin() == entry.amountRange.getMax() ? String.valueOf((int)entry.amountRange.getMin()) : (int)entry.amountRange.getMin() + "-" + (int)entry.amountRange.getMax());
+                StringBuilder builder = new StringBuilder("item:");
+                String notes = entry.getNotes();
+
+                builder.append(entryName);
+
+                if (entry.isTable || entryName.equals("Nothing"))
+                    builder.append("; image:none");
+
+                builder.append("; weight:");
+                builder.append(entry.weight);
+
+                if (amount != null) {
+                    builder.append("; quantity:");
+                    builder.append(amount);
+                }
+
+                if (entry.bonusRange != null && (entry.bonusRange.getMin() != 0 || entry.bonusRange.getMax() != 0)) {
+                    builder.append("; looting: ");
+                    builder.append((int)entry.bonusRange.getMin());
+
+                    if (entry.bonusRange.getMax() != entry.bonusRange.getMin()) {
+                        builder.append("-");
+                        builder.append((int)entry.bonusRange.getMax());
+                    }
+                }
+
+                builder.append("; group:");
+                builder.append(poolNum);
+
+                if (notes.length() > 0) {
+                    builder.append("; notes:");
+                    builder.append(notes);
+                }
+
+                write(builder.toString());
+            }
+
+            IRandomRange poolRolls = pool.rolls;
+
+            if (poolRolls instanceof ConstantRange) {
+                write("|rolls" + poolNum + "=" + ((ConstantRange)poolRolls).generateInt(new Random()));
+            } else if (poolRolls instanceof RandomValueRange) {
+                write("|rolls" + poolNum + "=" + (int)((RandomValueRange)poolRolls).getMin() + "-" + (int)((RandomValueRange)poolRolls).getMax());
+            } else {
+                AoAWikiHelperMod.LOGGER.error("Found some range type that's not constant or random value, skipping");
+            }
+
+            if (pool.bonusRolls != null && (pool.bonusRolls.getMin() != 0 || pool.bonusRolls.getMax() != 0))
+                write("|bonusrolls" + poolNum + "=" + (int)pool.bonusRolls.getMin() + (pool.bonusRolls.getMin() == pool.bonusRolls.getMax() ? "" : "-" + (int)pool.bonusRolls.getMax()));
+
+            String poolNotes = pool.getNotes();
+
+            if (!poolNotes.equals("")) {
+                write("|notes" + poolNum + "=" + poolNotes);
+            }
+        }
+
+        write("}}");
+        disableWriter();
+        sender.sendMessage(AoAWikiHelperMod.generateInteractiveMessagePrintout("Generated loot table: ", new File(configDir, fileName), name, copyToClipboard && AoAWikiHelperMod.copyFileToClipboard(new File(configDir, fileName)) ? ". Copied to clipboard" : ""));
+    }
+
+    private static void enableWriter(final String fileName) {
+        configDir = AoAWikiHelperMod.prepConfigDir("Loot Tables");
+
+        File streamFile = new File(configDir, fileName);
+
+        try {
+            if (streamFile.exists())
+                streamFile.delete();
+
+            streamFile.createNewFile();
+
+            writer = new PrintWriter(streamFile);
+        }
+        catch (Exception e) {}
+    }
+
+    private static void disableWriter() {
+        if (writer != null)
+            IOUtils.closeQuietly(writer);
+
+        writer = null;
+    }
+
+    private static void write(String line) {
+        if (writer != null)
+            writer.println(line);
+    }
+}

--- a/src/main/java/net/tslat/aoawikihelpermod/loottables/PrintLootTableCommand.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/loottables/PrintLootTableCommand.java
@@ -1,0 +1,114 @@
+package net.tslat.aoawikihelpermod.loottables;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.command.arguments.EntitySummonArgument;
+import net.minecraft.command.arguments.ResourceLocationArgument;
+import net.minecraft.command.arguments.SuggestionProviders;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.AxeItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.World;
+import net.minecraft.world.storage.loot.LootPool;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.tslat.aoa3.item.tool.axe.BaseAxe;
+import net.tslat.aoa3.item.weapon.sword.BaseSword;
+import net.tslat.aoa3.util.NumberUtil;
+import net.tslat.aoa3.util.StringUtil;
+import net.tslat.aoawikihelpermod.AoAWikiHelperMod;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PrintLootTableCommand {
+    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+        dispatcher.register(
+                Commands.literal("printloottable")
+                        .then(Commands.argument("lootTableId", ResourceLocationArgument.resourceLocation())
+                                .then(Commands.argument("copyToClipboard", BoolArgumentType.bool())
+                                        .executes(commandContext -> {
+                                            print(commandContext, ResourceLocationArgument.getResourceLocation(commandContext, "lootTableId"), BoolArgumentType.getBool(commandContext, "copyToClipboard"));
+                                            return 0;
+                                        }))
+                                .executes(commandContext -> {
+                                    print(commandContext, ResourceLocationArgument.getResourceLocation(commandContext, "lootTableId"), false);
+                                    return 0;
+                                })));
+    }
+    public static void print(CommandContext<CommandSource> context, ResourceLocation lootTableId, boolean attemptToCopy) {
+        Entity sender = context.getSource().getEntity();
+
+        if(!(sender instanceof PlayerEntity)) {
+            sender.sendMessage(new StringTextComponent("This command can only be done ingame for accuracy."));
+            return;
+        }
+
+        PlayerEntity player = (PlayerEntity)sender;
+
+        World world = context.getSource().getWorld();
+
+        if(!world.isRemote) {
+
+            LootTable table = ServerLifecycleHooks.getCurrentServer().getLootTableManager().getLootTableFromLocation(lootTableId);
+
+            if (table == LootTable.EMPTY_LOOT_TABLE) {
+                sender.sendMessage(new StringTextComponent(TextFormatting.RED + "Unable to find loot table: " + lootTableId));
+
+                return;
+            }
+
+            String[] pathSplit = lootTableId.toString().substring(Math.max(0, lootTableId.toString().indexOf(":"))).split("/");
+            List<LootPool> pools = ObfuscationReflectionHelper.getPrivateValue(LootTable.class, table, "field_186466_c");
+            String tableName = AoAWikiHelperMod.capitaliseAllWords(pathSplit[pathSplit.length - 1].replace("_", " "));
+            boolean copyToClipboard = false;
+            String type = "";
+
+            /*
+            for (int i = 1; i < args.length; i++) {
+                switch (args[i].toLowerCase()) {
+                    case "clipboard":
+                        copyToClipboard = true;
+                        break;
+                    case "chest":
+                        type = "chest";
+                        break;
+                    case "generic":
+                        type = "generic";
+                    default:
+                        break;
+                }
+            }
+            */
+
+            if (pools.isEmpty()) {
+                sender.sendMessage(new StringTextComponent("Loot table " + lootTableId + " is empty. Nothing to print."));
+
+                return;
+            }
+
+            if (copyToClipboard && context.getSource().getServer().isDedicatedServer()) {
+                sender.sendMessage(new StringTextComponent("Can't copy contents of file to clipboard on dedicated servers, skipping."));
+                copyToClipboard = false;
+            }
+
+            LootTableWriter.writeTable(tableName, pools, sender, copyToClipboard, type);
+        }
+    }
+}
+

--- a/src/main/java/net/tslat/aoawikihelpermod/loottables/TestLootTableCommand.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/loottables/TestLootTableCommand.java
@@ -1,0 +1,201 @@
+package net.tslat.aoawikihelpermod.loottables;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.command.arguments.ResourceLocationArgument;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.World;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraft.world.storage.loot.*;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.tslat.aoa3.advent.AdventOfAscension;
+import net.tslat.aoa3.util.NumberUtil;
+import net.tslat.aoa3.util.StringUtil;
+import net.tslat.aoawikihelpermod.AoAWikiHelperMod;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class TestLootTableCommand {
+    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+        dispatcher.register(
+                Commands.literal("testloottable")
+                        .then(Commands.argument("lootTableId", ResourceLocationArgument.resourceLocation())
+                                .then(Commands.argument("luck", IntegerArgumentType.integer())
+                                    .then(Commands.argument("timesToTest", IntegerArgumentType.integer())
+                                            .then(Commands.argument("printToConsole", BoolArgumentType.bool())
+                                                    .executes(commandContext -> {
+                                                        print(commandContext,
+                                                                ResourceLocationArgument.getResourceLocation(commandContext, "lootTableId"),
+                                                                IntegerArgumentType.getInteger(commandContext, "luck"),
+                                                                IntegerArgumentType.getInteger(commandContext, "timesToTest"),
+                                                                BoolArgumentType.getBool(commandContext, "printToConsole")
+                                                        );
+                                                        return 0;
+                                                    }))
+                                            .executes(commandContext -> {
+                                                print(commandContext,
+                                                        ResourceLocationArgument.getResourceLocation(commandContext, "lootTableId"),
+                                                        IntegerArgumentType.getInteger(commandContext, "luck"),
+                                                        IntegerArgumentType.getInteger(commandContext, "timesToTest"),
+                                                        false
+                                                );
+                                                return 0;
+                                            })))));
+
+    }
+
+    public static void print(CommandContext<CommandSource> context, ResourceLocation lootTableId, int luck, int timesToTest, boolean printToConsole) {
+        Entity sender = context.getSource().getEntity();
+
+        if(!(sender instanceof PlayerEntity)) {
+            sender.sendMessage(new StringTextComponent("This command can only be done ingame for accuracy."));
+            return;
+        }
+
+        PlayerEntity player = (PlayerEntity)sender;
+
+        World world = context.getSource().getWorld();
+
+        if(!world.isRemote) {
+
+            try {
+                LootTable table = ServerLifecycleHooks.getCurrentServer().getLootTableManager().getLootTableFromLocation(lootTableId);
+
+                if (table == LootTable.EMPTY_LOOT_TABLE) {
+                    sender.sendMessage(new StringTextComponent("Unable to find loot table: " + lootTableId));
+
+                    return;
+                }
+
+                LootPool specificPool = null;
+
+             /*
+                if (arg.contains("pool:")) {
+                    specificPool = table.getPool(arg.split("pool:")[1]);
+                }*/
+
+
+                LootContext lootContext = new LootContext.Builder((ServerWorld)world)
+                        .withParameter(LootParameters.POSITION, new BlockPos(0, 0, 0))
+                        .withParameter(LootParameters.THIS_ENTITY, ForgeRegistries.ENTITIES.getValue(new ResourceLocation("aoa3", "charger")).create(player.getEntityWorld()))
+                        .withParameter(LootParameters.DAMAGE_SOURCE, DamageSource.causePlayerDamage(player))
+                        .withParameter(LootParameters.LAST_DAMAGE_PLAYER, player)
+                        .withLuck(luck)
+                        .build(LootParameterSets.ENTITY);
+
+                HashMap<String, Integer> lootMap = new HashMap<String, Integer>();
+
+                for (int i = 0; i < timesToTest; i++) {
+                    List<ItemStack> lootStacks;
+                    /*
+                    if (specificPool != null) {
+                        specificPool.generateLoot(lootStacks = new ArrayList<ItemStack>(), world.rand, context);
+                    }
+                    else {*/
+                        lootStacks = table.generate(lootContext);
+                    /*}*/
+
+                    if (lootStacks.isEmpty())
+                        lootMap.merge("empty", 1, Integer::sum);
+
+                    for (ItemStack stack : lootStacks) {
+                        lootMap.merge(stack.getTranslationKey(), 1, Integer::sum);
+                    }
+                }
+
+                HashMap<String, Integer> sortedLootMap = lootMap.entrySet().stream().sorted(Collections.reverseOrder(Map.Entry.comparingByValue())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v2, LinkedHashMap::new));
+
+                if (printToConsole || player == null) {
+                    System.out.print("---~~~---~~~---~~~\n");
+                    System.out.print("AoA v" + AdventOfAscension.VERSION + " loot table printout: " + lootTableId + "\n");
+
+                    if (specificPool != null)
+                        System.out.print("Pool: " + specificPool.getName());
+
+                    System.out.print("\n");
+                    System.out.print("---~~~---~~~---~~~\n");
+                    System.out.print("    Total rolls: " + timesToTest + "\n");
+                    System.out.print("    With luck: " + luck + "\n");
+
+                    if (player != null)
+                        System.out.print("    Tested as a player\n");
+
+                    System.out.print("    Drops:\n");
+
+                    int count = 0;
+                    Integer emptyDrops = sortedLootMap.get("empty");
+
+                    if (emptyDrops == null)
+                        emptyDrops = 0;
+
+                    for (Integer val : sortedLootMap.values()) {
+                        count += val;
+                    }
+
+                    System.out.print("        " + TextFormatting.DARK_GRAY + "Empty: " + TextFormatting.GRAY + emptyDrops + TextFormatting.RESET + " times. (" + TextFormatting.GRAY + NumberUtil.roundToNthDecimalPlace((emptyDrops / (float)timesToTest) * 100, 5) + "%" + TextFormatting.RESET + ")\n");
+
+                    sortedLootMap.remove("empty");
+
+                    for (Map.Entry<String, Integer> entry : sortedLootMap.entrySet()) {
+                        System.out.print("        " + TextFormatting.DARK_GRAY + "Item: " + TextFormatting.GOLD + I18n.format(entry.getKey()) + TextFormatting.RESET + ", dropped " + TextFormatting.GRAY + entry.getValue() + TextFormatting.RESET + " times. (" + TextFormatting.GRAY + NumberUtil.roundToNthDecimalPlace((entry.getValue() / (float)count) * 100, 5) + "%" + TextFormatting.RESET + ")\n");
+                    }
+
+                    int dropCount = count - emptyDrops;
+
+                    System.out.print("\n");
+                    System.out.print("Total drops: " + dropCount + ". Drop ratio: " + dropCount + "/" + timesToTest + " (" + NumberUtil.roundToNthDecimalPlace(dropCount / (float)timesToTest, 5) + ")\n");
+                    System.out.print("---~~~---~~~---~~~\n");
+                }
+                else {
+                    System.out.print("---~~~---~~~---~~~\n");
+                    sender.sendMessage(new StringTextComponent("AoA v" + AdventOfAscension.VERSION + " loot table printout: " + lootTableId));
+                    sender.sendMessage(new StringTextComponent("---~~~---~~~---~~~"));
+                    sender.sendMessage(new StringTextComponent("Total rolls: " + timesToTest));
+                    sender.sendMessage(new StringTextComponent("With luck: " + luck));
+                    sender.sendMessage(new StringTextComponent("Drops:"));
+
+                    int count = 0;
+                    Integer emptyDrops = sortedLootMap.get("empty");
+
+                    if (emptyDrops == null)
+                        emptyDrops = 0;
+
+                    for (Integer val : sortedLootMap.values()) {
+                        count += val;
+                    }
+
+                    sender.sendMessage(new StringTextComponent(TextFormatting.DARK_GRAY + "Empty: " + TextFormatting.GRAY + emptyDrops + TextFormatting.RESET + " times. (" + TextFormatting.GRAY + NumberUtil.roundToNthDecimalPlace((emptyDrops / (float)timesToTest) * 100, 5) + "%" + TextFormatting.RESET + ")"));
+
+                    sortedLootMap.remove("empty");
+
+                    for (Map.Entry<String, Integer> entry : sortedLootMap.entrySet()) {
+                        sender.sendMessage(new StringTextComponent(TextFormatting.DARK_GRAY + "Item: " + TextFormatting.GOLD + I18n.format(entry.getKey()) + TextFormatting.RESET + ", dropped " + TextFormatting.GRAY + entry.getValue() + TextFormatting.RESET + " times. (" + TextFormatting.GRAY + NumberUtil.roundToNthDecimalPlace((entry.getValue() / (float)count) * 100, 5) + "%" + TextFormatting.RESET + ")"));
+                    }
+
+                    int dropCount = count - 0;
+
+                    sender.sendMessage(new StringTextComponent("Total drops: " + dropCount + ". Drop ratio: " + dropCount + "/" + timesToTest + " (" + NumberUtil.roundToNthDecimalPlace(dropCount / (float)timesToTest, 5) + ")"));
+                }
+            } catch (Exception ex) {
+                sender.sendMessage(new StringTextComponent("Unable to test loot table: " + lootTableId));
+                ex.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/net/tslat/aoawikihelpermod/recipes/InfusionEnchantsWriter.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/recipes/InfusionEnchantsWriter.java
@@ -1,0 +1,223 @@
+package net.tslat.aoawikihelpermod.recipes;
+
+import net.minecraft.command.ICommandSource;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentData;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.RecipeManager;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.Registry;
+import net.tslat.aoa3.advent.AdventOfAscension;
+import net.tslat.aoa3.common.container.recipe.InfusionRecipe;
+
+import net.tslat.aoawikihelpermod.AoAWikiHelperMod;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Comparator;
+
+public class InfusionEnchantsWriter {
+    public static File configDir = null;
+    private static PrintWriter writer = null;
+
+    public static void printImbuingEntries(ICommandSource sender, RecipeManager manager, boolean copyToClipboard) {
+        String fileName = "Infusion Enchants Printout " + AdventOfAscension.VERSION + ".txt";
+
+        enableWriter(fileName);
+
+        ArrayList<InfusionRecipe> imbuingRecipes = new ArrayList<InfusionRecipe>();
+
+        for (IRecipe recipe: manager.getRecipes()) {
+            if (recipe.getId() == null || !recipe.getId().getNamespace().equals("aoa3"))
+                continue;
+
+            if (recipe instanceof InfusionRecipe) {
+                InfusionRecipe infusionRecipe = (InfusionRecipe)recipe;
+
+                if (infusionRecipe.isEnchanting()) {
+                    imbuingRecipes.add(infusionRecipe);
+                }
+            }
+
+        }
+
+        imbuingRecipes.sort(new InfusionRecipeComparator());
+
+        write("{|cellpadding=\"5\" cellspacing=\"0\" border=\"1\" style=\"text-align:center\"");
+        write("|-style=\"background-color:#f2f2f2\"|");
+        write("! Enchantment !! Description !! Applies to !! Base Recipe !! Infusion Level");
+        write("|-");
+
+        Enchantment lastEnchantRow = null;
+        ArrayList<Integer> enchantLevels = new ArrayList<Integer>();
+        ArrayList<Integer> enchantLevelValues = new ArrayList<Integer>();
+
+        for (InfusionRecipe recipe : imbuingRecipes) {
+            System.out.println(recipe.getId());
+            EnchantmentData enchData = getEnchantmentData(recipe);
+
+            if (enchData.enchantment == lastEnchantRow) {
+                enchantLevels.add(enchData.enchantmentLevel);
+                enchantLevelValues.add(recipe.getInfusionReq());
+            }
+            else {
+                if (lastEnchantRow != null) {
+                    StringBuilder builder = new StringBuilder();
+
+                    for (Integer lvl : enchantLevels) {
+                        builder.append(" !! Level ").append(lazyNumberToRoman(lvl));
+                    }
+
+                    write(builder.toString().substring(2));
+                    write("|-");
+
+                    builder = new StringBuilder();
+
+                    for (Integer lvl : enchantLevelValues) {
+                        builder.append(" || ").append(lvl);
+                    }
+
+                    write(builder.toString().substring(2));
+                    write("|}");
+                    write("|-");
+                    enchantLevels.clear();
+                    enchantLevelValues.clear();
+                }
+
+                String enchantName = I18n.format(enchData.enchantment.getName());
+                String desc = I18n.format(enchData.enchantment.getName() + ".desc");
+                String appliesTo = RecipeInterfaceInfusion.getImbuingApplicableTo(enchData.enchantment);
+                RecipeInterfaceInfusion recipeInterface = (RecipeInterfaceInfusion)RecipeWriter.findRecipeInterface(recipe);
+
+                if (desc.equals(enchData.enchantment.getName() + ".desc"))
+                    desc = "?";
+
+                write("| '''" + enchantName + "''' || " + desc + " || " + appliesTo + " ||");
+                write("{{Infusion");
+
+                for (String line : recipeInterface.buildAdditionalTemplateLines(recipe.getEnchantmentAsBook(), true)) {
+                    write(line);
+                }
+
+                write("}}");
+                write("||");
+                write("{|class=\"wikitable\"");
+                write("|-");
+                enchantLevels.add(enchData.enchantmentLevel);
+                enchantLevelValues.add(recipe.getInfusionReq());
+
+                lastEnchantRow = enchData.enchantment;
+            }
+        }
+
+        StringBuilder builder = new StringBuilder();
+
+        for (Integer lvl : enchantLevels) {
+            builder.append(" !! Level ").append(lazyNumberToRoman(lvl));
+        }
+
+        write(builder.toString().substring(2));
+        write("|-");
+
+        builder = new StringBuilder();
+
+        for (Integer lvl : enchantLevelValues) {
+            builder.append(" || ").append(lvl);
+        }
+
+        write(builder.toString().substring(2));
+        write("|}");
+        write("|-");
+        enchantLevels.clear();
+        enchantLevelValues.clear();
+
+        write("|}");
+
+        disableWriter();
+        sender.sendMessage(AoAWikiHelperMod.generateInteractiveMessagePrintout("Generated data file: ", new File(configDir, fileName), "Infusion Enchants", copyToClipboard && AoAWikiHelperMod.copyFileToClipboard(new File(configDir, fileName)) ? ". Copied to clipboard" : ""));
+    }
+
+    private static String lazyNumberToRoman(int number) {
+        switch (number) {
+            case 0:
+                return "0";
+            case 1:
+                return "I";
+            case 2:
+                return "II";
+            case 3:
+                return "III";
+            case 4:
+                return "IV";
+            case 5:
+                return "V";
+            case 6:
+                return "VI";
+            case 7:
+                return "VII";
+            case 8:
+                return "VIII";
+            case 9:
+                return "IX";
+            case 10:
+                return "X";
+            default:
+                return String.valueOf(number);
+        }
+    }
+
+    private static void enableWriter(final String fileName) {
+        configDir = AoAWikiHelperMod.prepConfigDir("Misc Printouts");
+
+        File streamFile = new File(configDir, fileName);
+
+        try {
+            if (streamFile.exists())
+                streamFile.delete();
+
+            streamFile.createNewFile();
+
+            writer = new PrintWriter(streamFile);
+        }
+        catch (Exception e) {}
+    }
+
+    private static void disableWriter() {
+        if (writer != null)
+            IOUtils.closeQuietly(writer);
+
+        writer = null;
+    }
+
+    private static void write(String line) {
+        if (writer != null)
+            writer.println(line);
+    }
+
+    private static EnchantmentData getEnchantmentData(InfusionRecipe recipe) {
+        CompoundNBT enchantTag = recipe.getEnchantmentAsBook().getTag().getList("StoredEnchantments", 10).getCompound(0);
+
+        return new EnchantmentData(Registry.ENCHANTMENT.getOrDefault(new ResourceLocation(enchantTag.getString("id"))), enchantTag.getShort("lvl"));
+    }
+
+    private static class InfusionRecipeComparator implements Comparator<InfusionRecipe> {
+        @Override
+        public int compare(InfusionRecipe recipe1, InfusionRecipe recipe2) {
+            try {
+                EnchantmentData enchant1 = getEnchantmentData(recipe1);
+                EnchantmentData enchant2 = getEnchantmentData(recipe2);
+
+                return (I18n.format(enchant1.enchantment.getName()) + enchant1.enchantmentLevel).compareTo(I18n.format(enchant2.enchantment.getName()) + enchant2.enchantmentLevel);
+            }
+            catch (Exception e) {
+                System.out.println("Found invalid enchanted book data from infusion recipe, skipping sort operation on this item");
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/main/java/net/tslat/aoawikihelpermod/recipes/InfusionEnchantsWriter.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/recipes/InfusionEnchantsWriter.java
@@ -57,7 +57,6 @@ public class InfusionEnchantsWriter {
         ArrayList<Integer> enchantLevelValues = new ArrayList<Integer>();
 
         for (InfusionRecipe recipe : imbuingRecipes) {
-            System.out.println(recipe.getId());
             EnchantmentData enchData = getEnchantmentData(recipe);
 
             if (enchData.enchantment == lastEnchantRow) {

--- a/src/main/java/net/tslat/aoawikihelpermod/recipes/PrintInfusionEnchantsCommand.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/recipes/PrintInfusionEnchantsCommand.java
@@ -1,0 +1,61 @@
+package net.tslat.aoawikihelpermod.recipes;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.World;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.tslat.aoa3.item.tool.axe.BaseAxe;
+import net.tslat.aoa3.util.NumberUtil;
+import net.tslat.aoawikihelpermod.weaponcategories.CategoryTableWriter;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PrintInfusionEnchantsCommand {
+    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+        dispatcher.register(
+                Commands.literal("printinfusionenchants")
+                        .then(Commands.argument("copyToClipboard", BoolArgumentType.bool())
+                                .executes(commandContext -> {
+                                    print(commandContext, BoolArgumentType.getBool(commandContext, "copyToClipboard"));
+                                    return 0;
+                                }))
+                        .executes(commandContext -> {
+                            print(commandContext, false);
+                            return 0;
+                        }));
+    }
+
+    public static void print(CommandContext<CommandSource> context, boolean attemptToCopy) {
+        Entity sender = context.getSource().getEntity();
+
+        if(!(sender instanceof PlayerEntity)) {
+            sender.sendMessage(new StringTextComponent("This command can only be done ingame for accuracy."));
+            return;
+        }
+
+        PlayerEntity player = (PlayerEntity)sender;
+
+        World world = context.getSource().getWorld();
+
+        if(!world.isRemote) {
+            boolean copyToClipboard = attemptToCopy;
+            if (copyToClipboard && context.getSource().getServer().isDedicatedServer()) {
+                sender.sendMessage(new StringTextComponent("Can't copy contents of file to clipboard on dedicated servers, skipping."));
+                copyToClipboard = false;
+            }
+
+            InfusionEnchantsWriter.printImbuingEntries(player, world.getRecipeManager(), copyToClipboard);
+        }
+    }
+}

--- a/src/main/java/net/tslat/aoawikihelpermod/recipes/RecipeInterfaceInfusion.java
+++ b/src/main/java/net/tslat/aoawikihelpermod/recipes/RecipeInterfaceInfusion.java
@@ -66,7 +66,7 @@ public class RecipeInterfaceInfusion extends IRecipeInterface {
         else if (json.has("infusion")) {
             JsonObject enchantObj = JSONUtils.getJsonObject(json, "infusion");
             enchant = ForgeRegistries.ENCHANTMENTS.getValue(new ResourceLocation(JSONUtils.getString(enchantObj, "enchantment")));
-            enchantLevel = JSONUtils.getInt(enchantObj, "level");
+            enchantLevel = JSONUtils.getInt(enchantObj, "level", 1);
             inputItem = null;
         }
         else {
@@ -276,7 +276,8 @@ public class RecipeInterfaceInfusion extends IRecipeInterface {
         if (enchant == null)
             return super.buildSummaryLine(targetStack, matchedRecipes);
 
-        return "[[" + (enchant.getRegistryName().getNamespace().equals("minecraft") ? "mcw:" : "") + I18n.format(enchant.getName()) + "|" + "IV" + "]] || " + getImbuingApplicableTo(enchant) + " || " + buildIngredientSummaryLine(targetStack, matchedRecipes) + " || {{Infusion";
+        String enchantName = I18n.format(enchant.getName());
+        return "[[" + (enchant.getRegistryName().getNamespace().equals("minecraft") ? "mcw:" : "") + enchantName + "|" + enchantName + " " + lazyNumberToRoman(this.enchantLevel) + "]] || " + getImbuingApplicableTo(enchant) + " || " + buildIngredientSummaryLine(targetStack, matchedRecipes) + " || {{Infusion";
     }
 
     @Override
@@ -354,6 +355,35 @@ public class RecipeInterfaceInfusion extends IRecipeInterface {
                 return "Any item";
             default:
                 return "?";
+        }
+    }
+
+    private static String lazyNumberToRoman(int number) {
+        switch (number) {
+            case 0:
+                return "0";
+            case 1:
+                return "I";
+            case 2:
+                return "II";
+            case 3:
+                return "III";
+            case 4:
+                return "IV";
+            case 5:
+                return "V";
+            case 6:
+                return "VI";
+            case 7:
+                return "VII";
+            case 8:
+                return "VIII";
+            case 9:
+                return "IX";
+            case 10:
+                return "X";
+            default:
+                return String.valueOf(number);
         }
     }
 }


### PR DESCRIPTION
Fixed the imbuing recipes and added the feasible data printouts, as well as the loot table printing/testing command.

Issues:
-The clipboard is still broken
-Not sure yet how to handle multiple optional arguments in the command builder. This generally doesn't affect anything, since most things have only one optional argument (which is the clipboard argument), but it causes some problems like the loot table printing command not accepting a type, and the loot table testing command currently not allowing rolls for a specific loot pool (luck and repetitions are currently required arguments, and print to console is the optional argument).
-Some loot table testing (e.g. skellox, elkanyne, creepird) prints "air" instead of "empty", and when it does this the empty slot becomes 0%. Unsure exactly why this is the case
